### PR TITLE
Add `allow` configuration for nginx ingress

### DIFF
--- a/vscode/config.json
+++ b/vscode/config.json
@@ -34,6 +34,7 @@
   ],
   "options": {
     "ssl": true,
+    "allow": "172.30.32.2",
     "certfile": "fullchain.pem",
     "keyfile": "privkey.pem",
     "packages": [],
@@ -43,6 +44,7 @@
   "schema": {
     "log_level": "match(^(trace|debug|info|notice|warning|error|fatal)$)?",
     "ssl": "bool",
+    "allow": "str",
     "certfile": "str",
     "keyfile": "str",
     "packages": ["str"],

--- a/vscode/rootfs/etc/cont-init.d/nginx.sh
+++ b/vscode/rootfs/etc/cont-init.d/nginx.sh
@@ -4,6 +4,7 @@
 # Configures NGINX for use with code-server
 # ==============================================================================
 declare port
+declare allow
 declare certfile
 declare hassio_dns
 declare ingress_interface
@@ -29,8 +30,10 @@ fi
 
 ingress_port=$(bashio::addon.ingress_port)
 ingress_interface=$(bashio::addon.ip_address)
+allow=$(bashio::config 'allow')
 sed -i "s/%%port%%/${ingress_port}/g" /etc/nginx/servers/ingress.conf
 sed -i "s/%%interface%%/${ingress_interface}/g" /etc/nginx/servers/ingress.conf
+sed -i "s/%%allow%%/${allow}/g" /etc/nginx/servers/ingress.conf
 
 hassio_dns=$(bashio::dns.host)
 sed -i "s/%%hassio_dns%%/${hassio_dns}/g" /etc/nginx/includes/resolver.conf

--- a/vscode/rootfs/etc/nginx/servers/ingress.conf
+++ b/vscode/rootfs/etc/nginx/servers/ingress.conf
@@ -5,7 +5,7 @@ server {
     include /etc/nginx/includes/proxy_params.conf;
 
     location / {
-        allow   172.30.32.2;
+        allow   %%allow%%;
         deny    all;
 
         proxy_pass http://backend;


### PR DESCRIPTION
# Proposed Changes

> Allow configuring the ingress policy for VSCode. There are cases where the docker IP for
Hassio may be different, or access should be allowed from other IPs based on other network
policies and proxies.

## Related Issues

> None

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/